### PR TITLE
feat: setup#is returns mock for chaining

### DIFF
--- a/src/mocks/mock.spec.ts
+++ b/src/mocks/mock.spec.ts
@@ -102,6 +102,16 @@ describe('Mock', () => {
     expect(mock.Object.bar).toEqual('someValue');
   });
 
+  it('should allow setup chaining', () => {
+    const mock = new Mock<Foo>();
+
+    mock.setup(f => f.fighters).is(() => false)
+        .setup(f => f.bar).is('someValue');
+
+    expect(mock.Object.fighters()).toBeFalsy();
+    expect(mock.Object.bar).toEqual('someValue');
+  });
+
   it('should be able to mix extend and setup methods', () => {
     const mock = new Mock<Foo>();
 

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -43,6 +43,6 @@ export class Mock<T> {
     public setup<TProp>(value: (obj: T) => TProp): Setup<T, TProp> {
         let propertyName = value.toString().match(/return\s[\w\d_]*\.([\w\d$_]*)\;/)[1];
 
-        return new Setup(this._object, propertyName);
+        return new Setup(this, propertyName);
     }
 }

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -1,7 +1,5 @@
 import { Setup } from './setup';
 
-const FUNCTION_STRING = 'function';
-
 /** Class for mocking objects/interfaces in Typescript */
 export class Mock<T> {
 
@@ -27,7 +25,7 @@ export class Mock<T> {
     /** Extend the current mock object with implementation */
     public extend(object: Partial<{ [ key in keyof T ]: T[key] }>): this {
       Object.keys(object).forEach((key) => {
-        if (typeof object[key] === FUNCTION_STRING) {
+        if (typeof object[key] === 'function') {
           try {
             spyOn(object, key as keyof T).and.callThrough();
           } catch (e) {
@@ -41,7 +39,7 @@ export class Mock<T> {
 
     /** Setup a property or a method with using lambda style settings */
     public setup<TProp>(value: (obj: T) => TProp): Setup<T, TProp> {
-        let propertyName = value.toString().match(/return\s[\w\d_]*\.([\w\d$_]*)\;/)[1];
+        const propertyName = value.toString().match(/return\s[\w\d_]*\.([\w\d$_]*)\;/)[1];
 
         return new Setup(this, propertyName);
     }

--- a/src/mocks/setup.ts
+++ b/src/mocks/setup.ts
@@ -1,8 +1,6 @@
 import { Mock } from './mock';
 import Spy = jasmine.Spy;
 
-const FUNCTION_STRING = 'function';
-
 export class Setup<T, TReturn> {
 
     private spy: Spy;
@@ -21,9 +19,8 @@ export class Setup<T, TReturn> {
 
     /** Setup the return value for the setup of the property */
     public is(value: TReturn) : Mock<T> {
-
         this.mock.Object[this.key] = value;
-        if(typeof(value) === FUNCTION_STRING) {
+        if(typeof(value) === 'function') {
             this.spy = spyOn(this.mock.Object, this.key as keyof T).and.callThrough();
         }
         return this.mock;

--- a/src/mocks/setup.ts
+++ b/src/mocks/setup.ts
@@ -1,3 +1,4 @@
+import { Mock } from './mock';
 import Spy = jasmine.Spy;
 
 const FUNCTION_STRING = 'function';
@@ -7,11 +8,11 @@ export class Setup<T, TReturn> {
     private spy: Spy;
 
     constructor(
-        private object: T,
-        private key: string
+        private mock: Mock<T>,
+        private key: string,
     ) {
-        this.object[key] = <T>{};
-        this.spy = spyOn(this.object, key as keyof T);
+        mock.Object[key] = <T>{};
+        this.spy = spyOn(mock.Object, key as keyof T);
     }
 
     public get Spy() {
@@ -19,12 +20,12 @@ export class Setup<T, TReturn> {
     }
 
     /** Setup the return value for the setup of the property */
-    public is(value: TReturn) : Setup<T, TReturn> {
+    public is(value: TReturn) : Mock<T> {
 
-        this.object[this.key] = value;
+        this.mock.Object[this.key] = value;
         if(typeof(value) === FUNCTION_STRING) {
-            this.spy = spyOn(this.object, this.key as keyof T).and.callThrough();
+            this.spy = spyOn(this.mock.Object, this.key as keyof T).and.callThrough();
         }
-        return this;
-    }    
+        return this.mock;
+    }
 }


### PR DESCRIPTION
While I normally am a fan of putting magic strings into constants, FUNCTION_STRING doesn't really hold weight.  Typeof is type-safe, and therefore not magic, so if you put a string that is invalid then it will not compile.
 
        if (typeof object[key] === 'foo') {

Operator '===' cannot be applied to types '"string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"' and '"foo"'.