### PR TITLE
fix: broke previous api with change of setup#is return type

### DIFF
--- a/src/mocks/mock.spec.ts
+++ b/src/mocks/mock.spec.ts
@@ -152,6 +152,18 @@ describe('Mock', () => {
     expect(bah.fighters).toHaveBeenCalled();
   });
 
+  it('should return an undefined spy if there was no setup', () => {
+    expect(new Mock<Foo>().Spy).toBeUndefined();
+  });
+
+  it('should allow you to get the spy off of a setup function', () => {
+    const mock = new Mock<Foo>();
+    const spy = mock.setup(x => x.fighters).is(Mock.ANY_FUNC).Spy;
+
+    mock.Object.fighters();
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('should be able only spy a method with extend', () => {
     const bah = {} as Foo;
     const mock = new Mock<Foo>(bah);

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -6,6 +6,11 @@ export class Mock<T> {
     public static ANY_FUNC = () => undefined;
 
     private _object: T = <T>{};
+    private _setup?: Setup<T, any>;
+
+    get Spy() {
+      return this._setup && this._setup.Spy;
+    }
 
     /** Create mock from a Type */
     public static of<T>(type: { new (): T }): Mock<T> {
@@ -41,6 +46,7 @@ export class Mock<T> {
     public setup<TProp>(value: (obj: T) => TProp): Setup<T, TProp> {
         const propertyName = value.toString().match(/return\s[\w\d_]*\.([\w\d$_]*)\;/)[1];
 
-        return new Setup(this, propertyName);
+        this._setup = new Setup(this, propertyName);
+        return this._setup;
     }
 }


### PR DESCRIPTION
Up to you on this one but I noticed that the last release broke this functionality.  It is a little strange from an API standpoint due to mock having a spy that is from the last function setup but that is how we can retain that prior behavior.