### PR TITLE
fix: object indexer lookup was broken in typescript 2.5

### DIFF
--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -35,10 +35,10 @@ export class Mock<T> {
 
     /** Extend the current mock object with implementation */
     public extend(object: RecursivePartial<T>): this {
-        Object.keys(object).forEach((key) => {
+        Object.keys(object).forEach((key: keyof T) => {
             if (typeof object[key] === 'function') {
                 try {
-                    let spy = spyOn(object, key as keyof T).and.callThrough();
+                    let spy = spyOn(object, key).and.callThrough();
                     this._spies.set(key, () => spy);
                 } catch (e) {
                     // noop: the function is already spied on


### PR DESCRIPTION
Type 'string' cannot be used to index type 'Partial<{ [key in keyof T]: T[key] | Partial<any>; }>'.