### PR TITLE
Revert "feat: allows partials of nested objects"

### DIFF
--- a/src/mocks/mock.spec.ts
+++ b/src/mocks/mock.spec.ts
@@ -1,10 +1,6 @@
 import { Mock } from './mock';
 import { BADQUERY } from 'dns';
 
-interface Bar {
-  blah: string;
-  blurg: string;
-}
 class Foo {
     private bah = 'hi';
     bar = ':-P';
@@ -16,7 +12,6 @@ class Foo {
     static bar(): string {
         throw new Error();
     }
-    blah: Bar
 }
 
 describe('Mock', () => {
@@ -49,12 +44,6 @@ describe('Mock', () => {
 
             expect(mock.Object.fighters()).toBeUndefined();
             expect(mock.Object.fighters).toHaveBeenCalled();
-        });
-
-        it('should work with nested types', () => {
-            const mock = new Mock<Foo>({blah : {blurg : 'hi'}});
-
-            expect(mock.Object.blah.blurg).toEqual('hi');
         });
     });
 
@@ -167,12 +156,6 @@ describe('Mock', () => {
             expect(bah.fightersWithParams('test')).toBeUndefined();
             expect(bah.fightersVoid(1)).toBeUndefined();
         });
-
-        it('should work with nested types', () => {
-            const mock = new Mock<Foo>().extend({blah : {blurg : 'hi'}});
-
-            expect(mock.Object.blah.blurg).toEqual('hi');
-        });
     });
 
     describe('using setup()', () => {
@@ -268,16 +251,6 @@ describe('Mock', () => {
 
                 expect(mock.Object.fighters()).toBeFalsy();
                 expect(mock.Object.bar).toEqual('someValue');
-            });
-
-            it('should work with nested types', () => {
-                const mock = new Mock<Foo>();
-                const mockNested = new Mock<Bar>();
-
-                mockNested.setup(b => b.blurg).is('hi');
-                mock.setup(f => f.blah).is(mockNested.Object);
-
-                expect(mock.Object.blah.blurg).toEqual('hi');                
             });
         });
     });

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -1,7 +1,5 @@
 import { Setup } from './setup';
 
-export type RecursivePartial<T> = Partial<{ [key in keyof T]: RecursivePartial<T[key]> | T[key] }>;
-
 /** Class for mocking objects/interfaces in Typescript */
 export class Mock<T> {
 
@@ -25,7 +23,7 @@ export class Mock<T> {
     private _object: T = <T>{};
     private _spies: Map<string, () => jasmine.Spy> = new Map<string, () => jasmine.Spy>();
 
-    constructor(object: RecursivePartial<T> | T = <T>{}) {
+    constructor(object: Partial<{[key in keyof T]: T[key]}> | T = <T>{}) {
         this._object = object as T;
         this.extend(object);
     }
@@ -36,7 +34,7 @@ export class Mock<T> {
     }
 
     /** Extend the current mock object with implementation */
-    public extend(object: RecursivePartial<T>): this {
+    public extend(object: Partial<{[key in keyof T]: T[key]}>): this {
         Object.keys(object).forEach((key: keyof T) => {
             if (typeof object[key] === 'function' && !(jasmine as any).isSpy(object[key])) {
                 const spy = spyOn(object, key).and.callThrough();


### PR DESCRIPTION
This reverts commit 65e0be71678c1b693ce4f98c90530cb440e0d33b.

Unfortunately the recursive partial broke type safety in some scenarios. 