### PR TITLE
Optional propertyName parameter for setup() and spyOf() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,16 @@ When you now want to change the behavior during your test this is possible:
     expect(systemUnderTest.getSubValue()).toBe('fake another value');  // <-- Will SUCCEED
   });
 ```
+
+### A note on setup() and spyOf() methods
+
+Some test environments (for example, [Wallaby.js](https://wallabyjs.com/)) might be incompatible with `ts-mocks` library because these methods use dynamic property name inferring under the hood. In such cases you can try set the property name manually:
+
+```
+  mockCookieService.setup(cs => cs.get, 'get')
+
+  // also possible
+  mockCookieService.spyOf(cs => cs.get, 'get')
+```
+
+Make sure that the property that your lambda `cs => cs.get` returns and the property name `'get'` in the second argument are the same, otherwise the type safety might be broken.

--- a/src/mocks/mock.spec.ts
+++ b/src/mocks/mock.spec.ts
@@ -40,7 +40,7 @@ describe('Mock', () => {
         });
 
         it('should return undefined if using the Mock.ANY_FUNC', () => {
-            const mock = new Mock<Foo>({fighters : Mock.ANY_FUNC});
+            const mock = new Mock<Foo>({ fighters: Mock.ANY_FUNC });
 
             expect(mock.Object.fighters()).toBeUndefined();
             expect(mock.Object.fighters).toHaveBeenCalled();
@@ -135,7 +135,7 @@ describe('Mock', () => {
         it('should return undefined if using the Mock.ANY_FUNC', () => {
             const mock = new Mock<Foo>();
 
-            mock.extend({fighters : Mock.ANY_FUNC});
+            mock.extend({ fighters: Mock.ANY_FUNC });
 
             expect(mock.Object.fighters()).toBeUndefined();
             expect(mock.Object.fighters).toHaveBeenCalled();
@@ -304,7 +304,7 @@ describe('Mock', () => {
         });
 
         it('should return undefined for properties with setup', () => {
-            const mock = new Mock<Foo>({ bar: ';-)'});
+            const mock = new Mock<Foo>({ bar: ';-)' });
             const spy = mock.spyOf(x => x.bar);
 
             expect(spy).toBeUndefined();
@@ -334,7 +334,7 @@ describe('Mock', () => {
         describe('with extend()', () => {
             it('should return the current spy of that function', () => {
                 const mock = new Mock<Foo>();
-                mock.extend({ fighters: () => true});
+                mock.extend({ fighters: () => true });
                 const spy = mock.spyOf(x => x.fighters);
 
                 expect(mock.Object.fighters()).toBeTruthy();
@@ -343,8 +343,8 @@ describe('Mock', () => {
 
             it('should return the current spy of that function after extend multiple times', () => {
                 const mock = new Mock<Foo>();
-                mock.extend({ fighters: () => true});
-                mock.extend({ fighters: () => false});
+                mock.extend({ fighters: () => true });
+                mock.extend({ fighters: () => false });
                 const spy = mock.spyOf(x => x.fighters);
 
                 expect(mock.Object.fighters()).toBeFalsy();
@@ -354,7 +354,7 @@ describe('Mock', () => {
 
         describe('with constructor()', () => {
             it('should return the current spy of that function', () => {
-                const mock = new Mock<Foo>({ fighters: () => true});
+                const mock = new Mock<Foo>({ fighters: () => true });
                 const spy = mock.spyOf(x => x.fighters);
 
                 expect(mock.Object.fighters()).toBeTruthy();
@@ -364,9 +364,9 @@ describe('Mock', () => {
 
         describe('when mixing contructor/setup/extend', () => {
             it('should return the current spy of that function', () => {
-                const mock = new Mock<Foo>({ fighters: () => true});
+                const mock = new Mock<Foo>({ fighters: () => true });
                 mock.setup(x => x.fighters).is(() => false);
-                mock.extend({ fighters: () => true});
+                mock.extend({ fighters: () => true });
 
                 const spy = mock.spyOf(x => x.fighters);
 
@@ -392,4 +392,22 @@ describe('Mock', () => {
 
         mock.setup(m => m.fighters).is(() => false);
     });
+
+    it('setup() should use the provided propertyName string', () => {
+        const foo = new Foo();
+        const mock = new Mock(foo);
+
+        const spy = mock.setup(it => it.bar, 'fighters').Spy
+        mock.Object.fighters()
+        expect(spy).toHaveBeenCalled()
+    })
+
+    it('spyOf() should use the provided propertyName string', () => {
+        const foo = new Foo();
+        const mock = new Mock(foo);
+
+        const spy = mock.spyOf(it => it.bar, 'fighters')
+        mock.Object.fighters()
+        expect(spy).toHaveBeenCalled()
+    })
 });

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -23,7 +23,7 @@ export class Mock<T> {
     private _object: T = <T>{};
     private _spies: Map<string, () => jasmine.Spy> = new Map<string, () => jasmine.Spy>();
 
-    constructor(object: Partial<{[key in keyof T]: T[key]}> | T = <T>{}) {
+    constructor(object: Partial<{ [key in keyof T]: T[key] }> | T = <T>{}) {
         this._object = object as T;
         this.extend(object);
     }
@@ -34,7 +34,7 @@ export class Mock<T> {
     }
 
     /** Extend the current mock object with implementation */
-    public extend(object: Partial<{[key in keyof T]: T[key]}>): this {
+    public extend(object: Partial<{ [key in keyof T]: T[key] }>): this {
         Object.keys(object).forEach((key: keyof T) => {
             if (typeof object[key] === 'function' && !(jasmine as any).isSpy(object[key])) {
                 const spy = spyOn(object, key).and.callThrough();
@@ -46,8 +46,10 @@ export class Mock<T> {
     }
 
     /** Setup a property or a method with using lambda style settings */
-    public setup<TProp>(value: (obj: T) => TProp): Setup<T, TProp> {
-        const propertyName = this.getPropertyName(value);
+    public setup<TProp>(value: (obj: T) => TProp, propertyName?: string): Setup<T, TProp> {
+        if (!propertyName) {
+            propertyName = this.getPropertyName(value);
+        }
 
         let setup = new Setup(this, propertyName);
         this._spies.set(propertyName, () => setup.Spy);
@@ -62,8 +64,11 @@ export class Mock<T> {
      *  set with extend of setup/is
      *  REMARK:
      */
-    public spyOf<TProp>(value: (obj: T) => TProp): jasmine.Spy {
-        const propertyName = this.getPropertyName(value);
+    public spyOf<TProp>(value: (obj: T) => TProp, propertyName?: string): jasmine.Spy {
+        if (!propertyName) {
+            propertyName = this.getPropertyName(value);
+        }
+
         if (this._spies.has(propertyName)) {
             return this._spies.get(propertyName)();
         }

--- a/src/mocks/mock.ts
+++ b/src/mocks/mock.ts
@@ -45,7 +45,12 @@ export class Mock<T> {
         return this;
     }
 
-    /** Setup a property or a method with using lambda style settings */
+    /** 
+     * Setup a property or a method with using lambda style settings.
+     * @param propertyName can be used as a fallback for environments where 
+     * dynamic inferring of `propertyName` is not possible. 
+     * For example, can be helpful in Wallaby.js test runner.
+     */
     public setup<TProp>(value: (obj: T) => TProp, propertyName?: string): Setup<T, TProp> {
         if (!propertyName) {
             propertyName = this.getPropertyName(value);
@@ -60,9 +65,11 @@ export class Mock<T> {
         return value.toString().match(/(return|=>)\s[\w\d_]*\.([\w\d$_]*)\;?/)[2];
     }
 
-    /** Get the spy of method or property that has be
-     *  set with extend of setup/is
-     *  REMARK:
+    /** 
+     * Get the spy of method or property that has be set with extend of setup/is.
+     * @param propertyName can be used as a fallback for environments where 
+     * dynamic inferring of `propertyName` is not possible. 
+     * For example, can be helpful in Wallaby.js test runner.
      */
     public spyOf<TProp>(value: (obj: T) => TProp, propertyName?: string): jasmine.Spy {
         if (!propertyName) {


### PR DESCRIPTION
I use Wallaby.js test runner. It uses its own compilation process that transforms functions to some internal representation.

For example, here is how it transforms a simple `fun` lambda: 

```
    let fun = it => it.myProperty
    fun.toString() // ? function (it) { $_$wf(265); return $_$w(265, 9), it.myProperty; }
```

For this reason, the regex in [getPropertyName()](https://github.com/jjherscheid/ts-mocks/blob/d35ab6b388fa229bfad3abfd3ed85de8eb60c889/src/mocks/mock.ts#L57-L59) method doesn't work and throws error. 

The extension of the existing regex to support Wallaby.js isn't good enough solution because it would couple `ts-mocks` library with private API of Wallaby.js. So I have added optional `propertyName` arguments to `setup()` and `spyOf()`. If developer provides the second argument then `getPropertyName()` will not be called. If developer doesn't provide the second argument then the methods work without changes.

Still, developers should take care of constancy, i.e. the property name in the lambda and in the second must be the same to keep the type safety.  

I've added corresponding tests for the new feature and made sure the existing tests are green.

In addition, my linter formatted some of your code. I have checked the changes and they look reasonable to me. If you don't like it then I'll revert it.